### PR TITLE
Shortcode for compare button, compare button on product single

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@
 Contributors: addonify
 Tags: compare, woocommerce compare, products comparison, compare products, compare woocommerce, addonify, woocommerce
 Requires at least: 5.9
-Tested up to: 6.2.2
-Stable tag: 1.1.10
+Tested up to: 6.3
+Stable tag: 1.1.11
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -74,6 +74,10 @@ Yes, Addonify Product Compare should work with all themes if the theme authors h
 
 Yes, you can select the fields from Dashboard > Addonify > Compare > Settings to display in the compare table.
 
+= Is there a shortcode for adding product compare button in the content?
+
+Yes, there is. Use `[addonify_compare_button]` to add product compare button in the content. Use `product_id` , `button_label`, `classes`, `display_button_icon`, and `button_icon_position` are the shortcode attributes that can be used. Shortcode attribute, `product_id` is required in order to display the compare button.
+
 = I'm a developer, is it possible to customize frontend output? =
 
 Yes, you can do it. Copy template from "/plublic/templates" the plugin's folder and paste them inside "/addonify/addonify-compare-products" of your theme's folder. For more information, read the [plugin's documentation](https://docs.addonify.com/kb/woocommerce-compare-products/)
@@ -97,6 +101,12 @@ Yes, you can do it. Copy template from "/plublic/templates" the plugin's folder 
 
 
 == Changelog ==
+
+= 1.1.11 - ? August, 2023 =
+
+- Added: Options to enable compare product button on product single page.
+- Added: Option to enable product button on product archive pages.
+- Added: Shortcode, `[addonify_compare_button]`, for adding compare button.
 
 = 1.1.10 - 20 June, 2023 =
 

--- a/addonify-compare-products.php
+++ b/addonify-compare-products.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Addonify - Compare Products For WooCommerce
  * Plugin URI:        https://wordpress.org/plugins/addonify-compare-products/
  * Description:       Addonify Compare Products is a WooCommerce extension that allows website visitors to compare multiple products on your online store.
- * Version:           1.1.10
+ * Version:           1.1.11
  * Author:            Addonify
  * Author URI:        https://addonify.com/
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'ADDONIFY_COMPARE_PRODUCTS_VERSION', '1.1.10' );
+define( 'ADDONIFY_COMPARE_PRODUCTS_VERSION', '1.1.11' );
 define( 'ADDONIFY_CP_DB_INITIALS', 'addonify_cp_' );
 define( 'ADDONIFY_CP_PLUGIN_PATH', dirname( __FILE__ ) );
 

--- a/includes/addonify-compare-products-helpers-functions.php
+++ b/includes/addonify-compare-products-helpers-functions.php
@@ -132,3 +132,20 @@ if ( ! function_exists( 'addonify_compare_products_is_empty_compare_cookie' ) ) 
 		return ( is_array( $compare_cookie ) && count( $compare_cookie ) === 0 ) ? true : false;
 	}
 }
+
+
+if ( ! function_exists( 'addonify_compare_products_get_selected_compare_button_icon' ) ) {
+	/**
+	 * Get selected compare button icon.
+	 *
+	 * @since 1.1.11
+	 *
+	 * @param string $selected_icon Selected icon.
+	 */
+	function addonify_compare_products_get_selected_compare_button_icon( $selected_icon = 'icon_one' ) {
+
+		$compare_button_icons = addonify_compare_products_get_compare_button_icons();
+
+		return $compare_button_icons[ $selected_icon ];
+	}
+}

--- a/includes/addonify-compare-products-template-functions.php
+++ b/includes/addonify-compare-products-template-functions.php
@@ -47,8 +47,6 @@ if ( ! function_exists( 'addonify_compare_products_locate_template' ) ) {
 }
 
 
-
-
 if ( ! function_exists( 'addonify_compare_products_get_template' ) ) {
 	/**
 	 * Get template file from plugin templates folder.
@@ -77,55 +75,22 @@ if ( ! function_exists( 'addonify_compare_products_get_template' ) ) {
 }
 
 
-
-
 if ( ! function_exists( 'addonify_compare_products_render_compare_button' ) ) {
 	/**
 	 * Renders the compare button in products loop.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @param array $args Button arguments.
 	 */
-	function addonify_compare_products_render_compare_button() {
-
-		global $product;
-
-		$compare_button_css_classes = array( 'button', 'addonify-cp-button' );
-
-		$button_icon = '';
-
-		if (
-			addonify_compare_products_get_option( 'compare_products_btn_show_icon' ) &&
-			addonify_compare_products_get_option( 'compare_products_btn_icon' )
-		) {
-
-			$compare_button_icon_key = addonify_compare_products_get_option( 'compare_products_btn_icon' );
-
-			$compare_button_icons = addonify_compare_products_get_compare_button_icons();
-
-			$button_icon = $compare_button_icons[ $compare_button_icon_key ];
-
-			if ( addonify_compare_products_get_option( 'compare_products_btn_icon_position' ) === 'left' ) {
-				$compare_button_css_classes[] = 'icon-position-left';
-			} else {
-				$compare_button_css_classes[] = 'icon-position-right';
-			}
-		}
-
-		$compare_button_args = array(
-			'product_id'  => $product->get_id(),
-			'label'       => addonify_compare_products_get_option( 'compare_products_btn_label' ),
-			'classes'     => apply_filters( 'addonify_compare_products_compare_button_css_classes', $compare_button_css_classes ),
-			'button_icon' => $button_icon,
-		);
+	function addonify_compare_products_render_compare_button( $args = array() ) {
 
 		addonify_compare_products_get_template(
 			'addonify-compare-products-button.php',
-			apply_filters( 'addonify_compare_products_compare_button_args', $compare_button_args )
+			apply_filters( 'addonify_compare_products_compare_button_args', $args )
 		);
 	}
 }
-
-
 
 
 if ( ! function_exists( 'addonify_compare_products_render_comparison_modal' ) ) {
@@ -168,8 +133,6 @@ if ( ! function_exists( 'addonify_compare_products_render_docker_modal' ) ) {
 }
 
 
-
-
 if ( ! function_exists( 'addonify_compare_products_render_search_modal' ) ) {
 	/**
 	 * Renders the search modal.
@@ -181,7 +144,6 @@ if ( ! function_exists( 'addonify_compare_products_render_search_modal' ) ) {
 		addonify_compare_products_get_template( 'addonify-compare-products-search-modal.php' );
 	}
 }
-
 
 
 if ( ! function_exists( 'addonify_compare_products_render_comparison_content' ) ) {
@@ -326,8 +288,6 @@ if ( ! function_exists( 'addonify_compare_products_render_comparison_content' ) 
 }
 
 
-
-
 if ( ! function_exists( 'addonify_compare_products_render_docker_message' ) ) {
 	/**
 	 * Renders the message in the docker.
@@ -349,8 +309,6 @@ if ( ! function_exists( 'addonify_compare_products_render_docker_message' ) ) {
 }
 
 
-
-
 if ( ! function_exists( 'addonify_compare_products_render_docker_add_button' ) ) {
 	/**
 	 * Renders the add button in the docker.
@@ -362,8 +320,6 @@ if ( ! function_exists( 'addonify_compare_products_render_docker_add_button' ) )
 		addonify_compare_products_get_template( 'docker/add-button.php' );
 	}
 }
-
-
 
 
 if ( ! function_exists( 'addonify_compare_products_render_docker_content' ) ) {
@@ -385,8 +341,6 @@ if ( ! function_exists( 'addonify_compare_products_render_docker_content' ) ) {
 		);
 	}
 }
-
-
 
 
 if ( ! function_exists( 'addonify_compare_products_render_docker_compare_button' ) ) {
@@ -411,8 +365,6 @@ if ( ! function_exists( 'addonify_compare_products_render_docker_compare_button'
 		);
 	}
 }
-
-
 
 
 if ( ! function_exists( 'addonify_compare_products_render_docker_search_result' ) ) {
@@ -452,6 +404,7 @@ if ( ! function_exists( 'addonify_compare_products_product_remove_button' ) ) {
 	}
 }
 
+
 if ( ! function_exists( 'addonify_compare_products_product_image' ) ) {
 	/**
 	 * HTML definition of product image displayed in compare table.
@@ -471,6 +424,7 @@ if ( ! function_exists( 'addonify_compare_products_product_image' ) ) {
 		);
 	}
 }
+
 
 if ( ! function_exists( 'addonify_compare_products_product_title' ) ) {
 	/**
@@ -547,7 +501,7 @@ if ( ! function_exists( 'addonify_compare_products_product_rating' ) ) {
 
 		$rating         = wc_get_rating_html( $product->get_average_rating() );
 		$ratings_count  = $product->get_rating_counts() ? count( $product->get_rating_counts() ) : 0;
-		$product_rating = ( $rating ) ? wp_kses_post( $rating ) . '(' . esc_html( $ratings_count ) . ')' : esc_html__('N/A', 'addonify-compare-products');
+		$product_rating = ( $rating ) ? wp_kses_post( $rating ) . '(' . esc_html( $ratings_count ) . ')' : esc_html__( 'N/A', 'addonify-compare-products' );
 
 		return apply_filters(
 			'addonify_compare_products_filter_product_rating',
@@ -590,6 +544,7 @@ if ( ! function_exists( 'addonify_compare_products_product_in_stock' ) ) {
 	}
 }
 
+
 if ( ! function_exists( 'addonify_compare_products_product_add_to_cart_button' ) ) {
 	/**
 	 * HTML definition of product add to cart button displayed in compare table.
@@ -609,6 +564,7 @@ if ( ! function_exists( 'addonify_compare_products_product_add_to_cart_button' )
 		);
 	}
 }
+
 
 if ( ! function_exists( 'addonify_compare_products_product_attribute_properties' ) ) {
 	/**
@@ -645,7 +601,7 @@ if ( ! function_exists( 'addonify_compare_products_product_attribute_properties'
 			}
 		}
 
-		$product_attribute_properties = ( $attribute_value_names ) ? wpautop( wptexturize( implode( ', ', $attribute_value_names ) ) ) : esc_html__('N/A', 'addonify-compare-products');
+		$product_attribute_properties = ( $attribute_value_names ) ? wpautop( wptexturize( implode( ', ', $attribute_value_names ) ) ) : esc_html__( 'N/A', 'addonify-compare-products' );
 
 		return apply_filters(
 			'addonify_compare_products_filter_product_attribute_properties',
@@ -655,6 +611,7 @@ if ( ! function_exists( 'addonify_compare_products_product_attribute_properties'
 		);
 	}
 }
+
 
 if ( ! function_exists( 'addonify_compare_products_product_weight' ) ) {
 	/**
@@ -666,7 +623,7 @@ if ( ! function_exists( 'addonify_compare_products_product_weight' ) ) {
 	 */
 	function addonify_compare_products_product_weight( $product ) {
 
-		$product_weight = ( $product->has_weight() && $product->get_weight() ) ? wc_format_weight( $product->get_weight() ) : esc_html__('N/A', 'addonify-compare-products');
+		$product_weight = ( $product->has_weight() && $product->get_weight() ) ? wc_format_weight( $product->get_weight() ) : esc_html__( 'N/A', 'addonify-compare-products' );
 
 		return apply_filters(
 			'addonify_compare_products_filter_product_weight',
@@ -675,6 +632,7 @@ if ( ! function_exists( 'addonify_compare_products_product_weight' ) ) {
 		);
 	}
 }
+
 
 if ( ! function_exists( 'addonify_compare_products_product_dimensions' ) ) {
 	/**
@@ -686,7 +644,7 @@ if ( ! function_exists( 'addonify_compare_products_product_dimensions' ) ) {
 	 */
 	function addonify_compare_products_product_dimensions( $product ) {
 
-		$product_dimensions = ( $product->has_dimensions() && $product->get_dimensions( false ) ) ? wc_format_dimensions( $product->get_dimensions( false ) ) : esc_html__('N/A', 'addonify-compare-products');
+		$product_dimensions = ( $product->has_dimensions() && $product->get_dimensions( false ) ) ? wc_format_dimensions( $product->get_dimensions( false ) ) : esc_html__( 'N/A', 'addonify-compare-products' );
 
 		return apply_filters(
 			'addonify_compare_products_filter_product_dimensions',
@@ -735,7 +693,7 @@ if ( ! function_exists( 'addonify_compare_products_product_additional_informatio
 				$additional_information_html .= '</div>';
 			}
 		} else {
-			$additional_information_html = esc_html__('N/A', 'addonify-compare-products');
+			$additional_information_html = esc_html__( 'N/A', 'addonify-compare-products' );
 		}
 
 		return apply_filters(

--- a/includes/setting-functions/fields/compare-button.php
+++ b/includes/setting-functions/fields/compare-button.php
@@ -19,19 +19,33 @@ if ( ! function_exists( 'addonify_compare_products_compare_button_general_fields
 	function addonify_compare_products_compare_button_general_fields() {
 
 		return array(
-			'compare_products_btn_position'      => array(
+			'compare_products_btn_position'           => array(
 				'type'        => 'select',
 				'className'   => '',
-				'label'       => __( 'Button Position', 'addonify-compare-products' ),
-				'description' => __( 'Choose where to place the compare button.', 'addonify-compare-products' ),
+				'label'       => __( 'Button Position in Product Archive Page', 'addonify-compare-products' ),
+				'description' => __( 'Choose where to place the compare button in archive product loop.', 'addonify-compare-products' ),
 				'choices'     => array(
 					'after_add_to_cart'  => __( 'After Add to Cart Button', 'addonify-compare-products' ),
 					'before_add_to_cart' => __( 'Before Add to Cart Button', 'addonify-compare-products' ),
 				),
-				'dependent'   => array( 'enable_product_comparison' ),
+				'dependent'   => array( 'enable_product_comparison', 'enable_product_comparison_on_archive' ),
 				'value'       => addonify_compare_products_get_option( 'compare_products_btn_position' ),
 			),
-			'compare_products_btn_label'         => array(
+			'compare_products_btn_position_on_single' => array(
+				'type'        => 'select',
+				'className'   => '',
+				'label'       => __( 'Button Position in Product Single Page', 'addonify-compare-products' ),
+				'description' => __( 'Choose where to place the compare button in archive product loop.', 'addonify-compare-products' ),
+				'choices'     => array(
+					'before_add_to_cart_form'   => __( 'Before Add to Cart Form', 'addonify-compare-products' ),
+					'before_add_to_cart_button' => __( 'Before Add to Cart Button', 'addonify-compare-products' ),
+					'after_add_to_cart_button'  => __( 'After Add to Cart Button', 'addonify-compare-products' ),
+					'after_add_to_cart_form'    => __( 'After Add to Cart Form', 'addonify-compare-products' ),
+				),
+				'dependent'   => array( 'enable_product_comparison', 'enable_product_comparison_on_single' ),
+				'value'       => addonify_compare_products_get_option( 'compare_products_btn_position_on_single' ),
+			),
+			'compare_products_btn_label'              => array(
 				'type'        => 'text',
 				'className'   => '',
 				'label'       => __( 'Button Label', 'addonify-compare-products' ),
@@ -39,7 +53,7 @@ if ( ! function_exists( 'addonify_compare_products_compare_button_general_fields
 				'dependent'   => array( 'enable_product_comparison' ),
 				'value'       => addonify_compare_products_get_option( 'compare_products_btn_label' ),
 			),
-			'compare_products_btn_show_icon'     => array(
+			'compare_products_btn_show_icon'          => array(
 				'type'        => 'switch',
 				'className'   => '',
 				'label'       => __( 'Show Icon', 'addonify-compare-products' ),
@@ -47,7 +61,7 @@ if ( ! function_exists( 'addonify_compare_products_compare_button_general_fields
 				'dependent'   => array( 'enable_product_comparison' ),
 				'value'       => addonify_compare_products_get_option( 'compare_products_btn_show_icon' ),
 			),
-			'compare_products_btn_icon'          => array(
+			'compare_products_btn_icon'               => array(
 				'type'          => 'radio',
 				'typeStyle'     => 'radioIcon', // Not used on Front-End Control. Only for Ref!
 				'renderChoices' => 'html',
@@ -58,7 +72,7 @@ if ( ! function_exists( 'addonify_compare_products_compare_button_general_fields
 				'dependent'     => array( 'enable_product_comparison', 'compare_products_btn_show_icon' ),
 				'value'         => addonify_compare_products_get_option( 'compare_products_btn_icon' ),
 			),
-			'compare_products_btn_icon_position' => array(
+			'compare_products_btn_icon_position'      => array(
 				'type'        => 'select',
 				'className'   => '',
 				'label'       => __( 'Icon Position', 'addonify-compare-products' ),

--- a/includes/setting-functions/fields/general.php
+++ b/includes/setting-functions/fields/general.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'addonify_compare_products_general_setting_fields' ) ) {
 	function addonify_compare_products_general_setting_fields() {
 
 		return array(
-			'enable_product_comparison'       => array(
+			'enable_product_comparison'            => array(
 				'label'       => __( 'Enable Products Comparison', 'addonify-compare-products' ),
 				'description' => __( 'If disabled, products comparison will not be functional.', 'addonify-compare-products' ),
 				'type'        => 'switch',
@@ -27,7 +27,23 @@ if ( ! function_exists( 'addonify_compare_products_general_setting_fields' ) ) {
 				'badge'       => 'Required',
 				'value'       => addonify_compare_products_get_option( 'enable_product_comparison' ),
 			),
-			'compare_products_display_type'   => array(
+			'enable_product_comparison_on_archive' => array(
+				'label'       => __( 'Enable Products Comparison on Product Archive Pages', 'addonify-compare-products' ),
+				'description' => __( 'If disabled, products comparison will not be functional on product archive pages.', 'addonify-compare-products' ),
+				'type'        => 'switch',
+				'className'   => '',
+				'dependent'   => array( 'enable_product_comparison' ),
+				'value'       => addonify_compare_products_get_option( 'enable_product_comparison_on_archive' ),
+			),
+			'enable_product_comparison_on_single'  => array(
+				'label'       => __( 'Enable Products Comparison on Product Single Page', 'addonify-compare-products' ),
+				'description' => __( 'If disabled, products comparison will not be functional on product single page.', 'addonify-compare-products' ),
+				'type'        => 'switch',
+				'className'   => '',
+				'dependent'   => array( 'enable_product_comparison' ),
+				'value'       => addonify_compare_products_get_option( 'enable_product_comparison_on_single' ),
+			),
+			'compare_products_display_type'        => array(
 				'type'        => 'select',
 				'className'   => '',
 				'placeholder' => __( 'Select a page', 'addonify-compare-products' ),
@@ -40,7 +56,7 @@ if ( ! function_exists( 'addonify_compare_products_general_setting_fields' ) ) {
 				),
 				'value'       => addonify_compare_products_get_option( 'compare_products_display_type' ),
 			),
-			'compare_page'                    => array(
+			'compare_page'                         => array(
 				'type'        => 'select',
 				'className'   => '',
 				'placeholder' => __( 'Select a page', 'addonify-compare-products' ),
@@ -50,7 +66,7 @@ if ( ! function_exists( 'addonify_compare_products_general_setting_fields' ) ) {
 				'choices'     => addonify_compare_products_get_pages(),
 				'value'       => addonify_compare_products_get_option( 'compare_page' ),
 			),
-			'compare_products_cookie_expires' => array(
+			'compare_products_cookie_expires'      => array(
 				'type'        => 'number',
 				'className'   => '',
 				'typeStyle'   => 'toggle', // Acceptable values - 'default', 'toggle' & slider.

--- a/includes/setting-functions/settings.php
+++ b/includes/setting-functions/settings.php
@@ -62,7 +62,10 @@ if ( ! function_exists( 'addonify_compare_products_settings_defaults' ) ) {
 			array(
 				// Settings.
 				'enable_product_comparison'                => true,
+				'enable_product_comparison_on_archive'     => true, // @since 1.1.11
+				'enable_product_comparison_on_single'      => false, // @since 1.1.11
 				'compare_products_btn_position'            => 'after_add_to_cart',
+				'compare_products_btn_position_on_single'  => 'after_add_to_cart_form', // @since 1.1.11
 				'compare_products_btn_show_icon'           => true,
 				'compare_products_btn_icon'                => 'icon_one',
 				'compare_products_btn_label'               => __( 'Compare', 'addonify-compare-products' ),

--- a/public/templates/addonify-compare-products-button.php
+++ b/public/templates/addonify-compare-products-button.php
@@ -19,8 +19,16 @@
 
 // direct access is disabled.
 defined( 'ABSPATH' ) || exit;
+
+if ( ! isset( $product ) || ! ( $product instanceof WC_Product ) ) {
+	global $product;
+}
 ?>
-<button type="button" class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" data-product_id="<?php echo esc_attr( $product_id ); ?>">
+<button
+	type="button"
+	class="button addonify-cp-button <?php echo is_array( $classes ) ? esc_attr( implode( ' ', $classes ) ) : esc_attr( $classes ); ?>"
+	data-product_id="<?php echo esc_attr( $product->get_id() ); ?>"
+>
 	<?php
 	if ( ! empty( $button_icon ) ) {
 		?>
@@ -28,6 +36,6 @@ defined( 'ABSPATH' ) || exit;
 		<?php
 	}
 	?>
-	<?php echo esc_html( $label ); ?>
+	<?php echo esc_html( $button_label ); ?>
 </button>
 <?php


### PR DESCRIPTION
- Added: Options to enable compare product button on product single page.
- Added: Option to enable product button on product archive pages.
- Added: Shortcode, `[addonify_compare_button]`, for adding compare button.